### PR TITLE
Switch the major version update to only run release.released event

### DIFF
--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -3,7 +3,7 @@ name: Keep the major version up-to-date
 
 on:
   release:
-    types: [published, edited, released]
+    types: [released]
 
 jobs:
   actions-tagger:


### PR DESCRIPTION
I noticed that the tool for updating the major version release was running twice after a minor or patch version release was created. I think it's being run on the published and released events.

<img width="1269" height="144" alt="Screenshot_2026-01-05_14-35-42" src="https://github.com/user-attachments/assets/cc621cc5-77e2-463a-82c4-c8e29a918107" />

This isn't really ideal or necessary because it would be creating the major version tag twice.

Additionally, the action-tagger action is actually warning that it's being used on a non-release event:

<img width="1292" height="472" alt="Screenshot_2026-01-05_14-36-07" src="https://github.com/user-attachments/assets/4f7fcaf6-1150-484a-a87d-699c4ccda0f3" />


This PR changes this workflow so it only runs once on release.